### PR TITLE
Use webpacker-react to embed React components within .erb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 3.5'
+gem 'webpacker-react'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,8 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
+    webpacker-react (0.3.2)
+      webpacker
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -247,6 +249,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webpacker (~> 3.5)
+  webpacker-react
 
 RUBY VERSION
    ruby 2.3.7p456

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,8 +7,14 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
+// Prob need to use WebpackerReact only from root packs
+import WebpackerReact from 'webpacker-react'
+//import Turbolinks from 'turbolinks'
+Turbolinks.start()
+
 import "src/application.scss"
 
 console.log('Hello World from Webpacker')
 
 import Hello from "src/hello_react"
+WebpackerReact.setup({ Hello })

--- a/app/javascript/src/hello_react.jsx
+++ b/app/javascript/src/hello_react.jsx
@@ -27,4 +27,4 @@ document.addEventListener('DOMContentLoaded', () => {
   )
 })
 
-export { Hello }
+export default Hello

--- a/app/views/levels/show.html.erb
+++ b/app/views/levels/show.html.erb
@@ -50,3 +50,5 @@ end.to_h %>
 
 %>
 <%#= javascript_pack_tag 'just_hello_react' %>
+
+<%= react_component('Hello', name: 'Spiders') %>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "babel-preset-react": "^6.24.1",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "react-dom": "^16.7.0",
+    "webpacker-react": "^0.3.2"
   },
   "devDependencies": {
     "webpack-dev-server": "2.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6763,6 +6763,11 @@ webpack@^3.12.0:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
+webpacker-react@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/webpacker-react/-/webpacker-react-0.3.2.tgz#18c417a3fd51978d0ca98b62a47454d800754e09"
+  integrity sha1-GMQXo/1Rl40MqYtipHRU2AB1Tgk=
+
 websocket-driver@>=0.5.1:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"


### PR DESCRIPTION
Works basically as described on the box, although you do have to modify
your packs to `export default`.

**OPINION:**
The nice thing about this gem is that it unifies a way to introduce React components. There's no need for different e.g. div, spans, selects, classNames, data-tags. It's consistent.

Drawback: It assumes all React components make sense to be inserted as divs, which isn't great for fallback, BUT you can use `:tag => :select` if necessary.
